### PR TITLE
Specify minimum versions for runtime dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -427,4 +427,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4ae8c5c755f570bf8ba6b9331def727d287ff0a9508e8edff2a4830c022329ad"
+content-hash = "6374def9e82650df182bff6b4810bb058fca0db743edf221505bbf1339080f42"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-rich = "*"
-typer = {version = "*", extras = ["all"]}
-wakeonlan = "*"
-websocket-client = "*"
+rich = ">= 13.0.0"
+typer = ">= 0.12.0"
+wakeonlan = ">= 2.0.0"
+websocket-client = " >= 1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "*"


### PR DESCRIPTION
This means Alga doesn't just allow any version of the dependencies to be installed, as they might not have the necessary functionality in the older versions.

It would be ideal to run tests against these lower ranges in CI to make sure they keep working. That would currently require using uv or PDM as they support installing the lowest version of packages that are allowed inside the range. It can be looked into later.