### PR TITLE
Add Python 3.14 to the list of tested Python versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,6 +54,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14-dev"
 
     steps:
       - name: Checkout the code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Home Automation",
     "Topic :: Multimedia",
     "Typing :: Typed",


### PR DESCRIPTION
3.14.0 alpha 1 is out so we can start testing with it.