### PR TITLE
Add "remote send" command for sending a remote button press

### DIFF
--- a/src/alga/__main__.py
+++ b/src/alga/__main__.py
@@ -9,6 +9,7 @@ from alga import (
     cli_input,
     cli_media,
     cli_power,
+    cli_remote,
     cli_setup,
     cli_sound_output,
     cli_volume,
@@ -21,6 +22,7 @@ app.add_typer(cli_channel.app, name="channel")
 app.add_typer(cli_input.app, name="input")
 app.add_typer(cli_media.app, name="media")
 app.add_typer(cli_power.app, name="power")
+app.add_typer(cli_remote.app, name="remote")
 app.add_typer(cli_sound_output.app, name="sound-output")
 app.add_typer(cli_volume.app, name="volume")
 

--- a/src/alga/cli_remote.py
+++ b/src/alga/cli_remote.py
@@ -1,0 +1,34 @@
+import ssl
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Annotated
+
+from typer import Argument, Typer
+from websocket import WebSocket
+
+from alga import client
+
+
+app = Typer(no_args_is_help=True, help="Remote control button presses")
+
+
+@contextmanager
+def _input_connection() -> Iterator[WebSocket]:  # pragma: no cover
+    response = client.request(
+        "ssap://com.webos.service.networkinput/getPointerInputSocket"
+    )
+
+    connection = WebSocket(sslopt={"cert_reqs": ssl.CERT_NONE})
+    connection.connect(response["socketPath"], suppress_origin=True, timeout=3)  # type: ignore[no-untyped-call]
+
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@app.command()
+def send(button: Annotated[str, Argument()]) -> None:
+    """Send a button press to the TV"""
+    with _input_connection() as connection:
+        connection.send(f"type:button\nname:{button.upper()}\n\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,9 @@ import pytest
 def mock_request() -> Iterator[mock.MagicMock]:
     with mock.patch("alga.client.request") as mocked:
         yield mocked
+
+
+@pytest.fixture
+def mock_input() -> Iterator[mock.MagicMock]:
+    with mock.patch("alga.cli_remote._input_connection") as mocked:
+        yield mocked.return_value.__enter__.return_value.send

--- a/tests/test_cli_remote.py
+++ b/tests/test_cli_remote.py
@@ -1,0 +1,19 @@
+from unittest.mock import MagicMock
+
+from faker import Faker
+from typer.testing import CliRunner
+
+from alga.__main__ import app
+
+
+runner = CliRunner()
+
+
+def test_send(faker: Faker, mock_input: MagicMock) -> None:
+    button = faker.pystr()
+
+    result = runner.invoke(app, ["remote", "send", button])
+
+    mock_input.assert_called_once_with(f"type:button\nname:{button.upper()}\n\n")
+    assert result.exit_code == 0
+    assert result.stdout == ""

--- a/usage.md
+++ b/usage.md
@@ -20,6 +20,7 @@ $ alga [OPTIONS] COMMAND [ARGS]...
 * `input`: HDMI and similar inputs
 * `media`: Control the playing media
 * `power`: Turn TV (or screen) on and off
+* `remote`: Remote control button presses
 * `setup`: Pair a new TV
 * `sound-output`: Audio output device
 * `version`: Print Alga version
@@ -460,6 +461,42 @@ Turn TV screen on
 ```console
 $ alga power screen-on [OPTIONS]
 ```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `alga remote`
+
+Remote control button presses
+
+**Usage**:
+
+```console
+$ alga remote [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `send`: Send a button press to the TV
+
+### `alga remote send`
+
+Send a button press to the TV
+
+**Usage**:
+
+```console
+$ alga remote send [OPTIONS] BUTTON
+```
+
+**Arguments**:
+
+* `BUTTON`: [required]
 
 **Options**:
 


### PR DESCRIPTION
This is convenient for navigating around the UI of the TV without a remote, especially for apps which don't have API calls available to get it to take specific actions.

Fixes #35.