### PR TITLE
Set TV channel using the channel ID instead of channel number

### DIFF
--- a/src/alga/cli_channel.py
+++ b/src/alga/cli_channel.py
@@ -36,10 +36,19 @@ def down() -> None:
 
 
 @app.command()
-def set(value: Annotated[int, Argument()]) -> None:
+def set(value: Annotated[str, Argument()]) -> None:
     """Change to specific channel"""
 
-    client.request("ssap://tv/openChannel", {"channelNumber": value})
+    if value.isnumeric():
+        # If a channel number is provided, we look up the channel ID as some models require it.
+        response = client.request("ssap://tv/getChannelList")
+
+        for channel in response["channelList"]:
+            if channel["channelNumber"] == value:
+                value = channel["channelId"]
+                break
+
+    client.request("ssap://tv/openChannel", {"channelId": value})
 
 
 @app.command()

--- a/tests/test_cli_channel.py
+++ b/tests/test_cli_channel.py
@@ -42,14 +42,29 @@ def test_down(mock_request: MagicMock) -> None:
     assert result.stdout == ""
 
 
-def test_set(faker: Faker, mock_request: MagicMock) -> None:
-    channel_number = faker.pyint()
+def test_set_channel_id(faker: Faker, mock_request: MagicMock) -> None:
+    channel_id = faker.pystr()
 
-    result = runner.invoke(app, ["channel", "set", f"{channel_number}"])
+    result = runner.invoke(app, ["channel", "set", channel_id])
 
     mock_request.assert_called_once_with(
-        "ssap://tv/openChannel", {"channelNumber": channel_number}
+        "ssap://tv/openChannel", {"channelId": channel_id}
     )
+    assert result.exit_code == 0
+    assert result.stdout == ""
+
+
+def test_set_channel_number(faker: Faker, mock_request: MagicMock) -> None:
+    channel_number = str(faker.pyint())
+    channel_id = faker.pystr()
+
+    mock_request.return_value = {
+        "channelList": [{"channelId": channel_id, "channelNumber": channel_number}]
+    }
+
+    result = runner.invoke(app, ["channel", "set", channel_number])
+
+    mock_request.assert_called_with("ssap://tv/openChannel", {"channelId": channel_id})
     assert result.exit_code == 0
     assert result.stdout == ""
 


### PR DESCRIPTION
Some models of TVs, e.g. the 50UN73006LA requires the `ssap://tv/openChannel` call to be provided with a channel ID instead of a channel number.

Since the channel ID is something obscure like "1_21_101_101_16515_17539_9018" it doesn't make sense for a user to try to input the ID manually. Instead this change makes the `channel set` command look up the list of channels to convert a channel number to a channel ID, if the input looks like a channel number.

Fixes #49.