### PR TITLE
Add `alga sound-output pick` command

### DIFF
--- a/src/alga/cli_sound_output.py
+++ b/src/alga/cli_sound_output.py
@@ -1,9 +1,11 @@
 from typing import Annotated
 
+from pzp import pzp
 from rich import print
 from typer import Argument, Typer
 
 from alga import client
+from alga.types import SoundOutputDevice
 
 
 app = Typer(no_args_is_help=True, help="Audio output device")
@@ -15,6 +17,26 @@ def get() -> None:
 
     response = client.request("ssap://audio/getSoundOutput")
     print(f"The current sound output is [bold]{response['soundOutput']}[/bold]")
+
+
+@app.command()
+def pick() -> None:
+    """Show picker for selecting a sound output device."""
+
+    sound_output_device = pzp(
+        candidates=[
+            SoundOutputDevice("tv_speaker", "TV Speaker"),
+            SoundOutputDevice("external_optical", "Optical Out Device"),
+            SoundOutputDevice("tv_external_speaker", "Optical Out Device + TV Speaker"),
+            SoundOutputDevice("external_arc", "HDMI (ARC) Device"),
+        ],
+        fullscreen=False,
+        layout="reverse",
+    )
+    if sound_output_device:
+        client.request(
+            "ssap://audio/changeSoundOutput", {"output": sound_output_device.id_}
+        )
 
 
 @app.command()

--- a/src/alga/types.py
+++ b/src/alga/types.py
@@ -28,3 +28,12 @@ class InputDevice:
 
     def __str__(self) -> str:
         return f"{self.name} ({self.id_})"
+
+
+@dataclass
+class SoundOutputDevice:
+    id_: str
+    name: str
+
+    def __str__(self) -> str:
+        return self.name

--- a/tests/test_cli_sound_output.py
+++ b/tests/test_cli_sound_output.py
@@ -1,9 +1,10 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from faker import Faker
 from typer.testing import CliRunner
 
 from alga.__main__ import app
+from alga.types import SoundOutputDevice
 
 
 runner = CliRunner()
@@ -30,3 +31,17 @@ def test_set(faker: Faker, mock_request: MagicMock) -> None:
     )
     assert result.exit_code == 0
     assert result.stdout == ""
+
+
+def test_pick(faker: Faker, mock_request: MagicMock) -> None:
+    sound_output_device = SoundOutputDevice(faker.pystr(), faker.pystr())
+
+    with patch("alga.cli_sound_output.pzp") as mock_pzp:
+        mock_pzp.return_value = sound_output_device
+
+        result = runner.invoke(app, ["sound-output", "pick"])
+
+    mock_request.assert_called_once_with(
+        "ssap://audio/changeSoundOutput", {"output": sound_output_device.id_}
+    )
+    assert result.exit_code == 0

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,6 @@
 from faker import Faker
 
-from alga.types import Channel, InputDevice
+from alga.types import Channel, InputDevice, SoundOutputDevice
 
 
 def test_channel(faker: Faker) -> None:
@@ -19,3 +19,10 @@ def test_input_device(faker: Faker) -> None:
     input_device = InputDevice({"id": faker.pystr(), "label": faker.pystr()})
 
     assert str(input_device) == f"{input_device.name} ({input_device.id_})"
+
+
+def test_sound_output_device(faker: Faker) -> None:
+    name = faker.pystr()
+    sound_output_device = SoundOutputDevice(faker.pystr(), name)
+
+    assert str(sound_output_device) == name

--- a/usage.md
+++ b/usage.md
@@ -567,6 +567,7 @@ $ alga sound-output [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `get`: Show the current output device
+* `pick`: Show picker for selecting a sound output...
 * `set`: Change the output device
 
 ### `alga sound-output get`
@@ -577,6 +578,20 @@ Show the current output device
 
 ```console
 $ alga sound-output get [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+### `alga sound-output pick`
+
+Show picker for selecting a sound output device.
+
+**Usage**:
+
+```console
+$ alga sound-output pick [OPTIONS]
 ```
 
 **Options**:


### PR DESCRIPTION
It makes it much easier to change the sound output device.

I haven't been able to find an API to list the possible sound output devices, so I've instead added a hardcoded list of devices which seems useful.