### PR TITLE
flake.nix: Fix typer and pzp dependencies on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,39 @@
                   hash = "sha256-zvR+Z/BRJ4Pug+JMwvOeWyO11MoMMrvXIb1k9IY2Zn4=";
                 };
               };
+              pzp = p.buildPythonPackage rec {
+                version = "0.0.25";
+                pname = "pzp";
+                format = "pyproject";
+                nativeBuildInputs = with p.pythonPackages; [
+                  poetry-core
+                  setuptools
+                ];
+                src = p.fetchPypi {
+                  inherit version pname;
+                  hash = "sha256-29OhVEM9By+SQ6Cb+SF/f3157FBDttCxDHHV8kpcx2Y=";
+                };
+              };
+              typer = p.buildPythonPackage rec {
+                version = "0.15.1";
+                pname = "typer";
+                format = "pyproject";
+                nativeBuildInputs = with p.pythonPackages; [
+                  poetry-core
+                  pdm-backend
+                ];
+                propagatedBuildInputs = with p.pythonPackages; [
+                  click
+                  shellingham
+                  rich
+                  typing-extensions
+                ];
+                src = p.fetchPypi {
+                  inherit version pname;
+                  hash = "sha256-oFiMCn+mihl4oGmBhld3j4ar5v9epqv0cvlAoIv+Two=";
+                };
+              };
+
             };
           };
         };


### PR DESCRIPTION
pzp is [not packaged](https://search.nixos.org/packages?channel=24.11&from=0&size=50&sort=relevance&type=packages&query=pzp) for NixOS, and [pythonPackages.typer](https://search.nixos.org/packages?channel=unstable&show=python312Packages.typer&from=0&size=50&sort=relevance&type=packages&query=typer) is currently at 0.12.5, whereas alga needs at least 0.15.0.

With the aforementioned flake.nix changes, the build works once again on NixOS Unstable as of Dec 23 2024