### PR TITLE
Disallow click 8.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 
 dependencies = [
     "cfgs >= 0.13.0",
+    "click < 8.2.0",
     "getmac >= 0.9.0",
     "pzp >=0.0.25",
     "rich >= 13.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cfgs" },
+    { name = "click" },
     { name = "getmac" },
     { name = "pzp" },
     { name = "rich" },
@@ -28,6 +29,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cfgs", specifier = ">=0.13.0" },
+    { name = "click", specifier = "<8.2.0" },
     { name = "getmac", specifier = ">=0.9.0" },
     { name = "pzp", specifier = ">=0.0.25" },
     { name = "rich", specifier = ">=13.0.0" },


### PR DESCRIPTION
It seems to be bring incompatibilities with Typer, and since it will be installed by default until a fix is made, it makes sense to not allow that version, since it otherwise will break Alga for new users.