### PR TITLE
Use latest version of Typer, unpin Click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,10 @@ classifiers = [
 
 dependencies = [
     "cfgs >= 0.13.0",
-    "click < 8.2.0",
     "getmac >= 0.9.0",
     "pzp >=0.0.25",
     "rich >= 13.0.0",
-    "typer >= 0.15.0",
+    "typer >= 0.15.4",
     "wakeonlan >= 2.0.0",
     "websocket-client >= 1.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,6 @@ version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "cfgs" },
-    { name = "click" },
     { name = "getmac" },
     { name = "pzp" },
     { name = "rich" },
@@ -29,11 +28,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cfgs", specifier = ">=0.13.0" },
-    { name = "click", specifier = "<8.2.0" },
     { name = "getmac", specifier = ">=0.9.0" },
     { name = "pzp", specifier = ">=0.0.25" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "typer", specifier = ">=0.15.0" },
+    { name = "typer", specifier = ">=0.15.4" },
     { name = "wakeonlan", specifier = ">=2.0.0" },
     { name = "websocket-client", specifier = ">=1.0.0" },
 ]


### PR DESCRIPTION
The latest version of Typer (v0.15.4) specifies that it shouldn't be used with Click 8.2+, so it's no longer necessary to specify a Click version range in Alga as long as we use the latest version of Typer.