### PR TITLE
Use ubuntu-24.04 for job releasing to PyPI

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -44,7 +44,7 @@ jobs:
           path: dist/
 
   upload:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     needs:
       - build
 


### PR DESCRIPTION
The pypa/gh-action-pypi-publish action requires use of Docker which is not available in the ubuntu-slim runners.